### PR TITLE
Fix pom versions and README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Currently only json config is supported, but in the future other implementations
     <groupId>org.godari.config-resolver</groupId>
     <artifactId>config-resolver-json</artifactId>
     <version>1.0.0</version>
-</dependency
+</dependency>
 ```
 <b>Define Configuration Override Rules:</b> Define your configuration override rules by specifying user groups, 
 custom expressions, and the properties to override in your configuration JSON.

--- a/config-resolver-api/pom.xml
+++ b/config-resolver-api/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.godari.config-resolver</groupId>
     <artifactId>config-resolver-api</artifactId>
-    <version>${project-version}</version>
+    <version>${project.version}</version>
 
     <parent>
         <groupId>org.godari</groupId>

--- a/config-resolver-json-tests/pom.xml
+++ b/config-resolver-json-tests/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.godari.config-resolver</groupId>
   <artifactId>config-resolver-json-tests</artifactId>
-  <version>${project-version}</version>
+  <version>${project.version}</version>
 
   <parent>
     <groupId>org.godari</groupId>

--- a/config-resolver-json/pom.xml
+++ b/config-resolver-json/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.godari.config-resolver</groupId>
     <artifactId>config-resolver-json</artifactId>
-    <version>${project-version}</version>
+    <version>${project.version}</version>
 
     <parent>
         <groupId>org.godari</groupId>


### PR DESCRIPTION
## Summary
- update module POMs to use `${project.version}` instead of undefined placeholder
- clean up README dependency snippet and final line

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2db80d28832e953438032d82cc93